### PR TITLE
remove SUPPORTS_MACCATALYST from user_target_xcconfig

### DIFF
--- a/SmartCodable.podspec
+++ b/SmartCodable.podspec
@@ -52,8 +52,7 @@ Pod::Spec.new do |s|
     }
 
     ss.user_target_xcconfig = {
-      "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/SmartCodable/release/SmartCodableMacros-tool#SmartCodableMacros",
-      "SUPPORTS_MACCATALYST" => "YES"
+      "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/SmartCodable/release/SmartCodableMacros-tool#SmartCodableMacros"
     }
 
     script = <<-SCRIPT


### PR DESCRIPTION
`user_target_xcconfig` 中的设置会影响其他`target`。 举个例子：假如依赖`SmartCodable`的 `SmartCodable_Example`一开始并未开启 `SUPPORTS_MACCATALYST`设置，但`SmartCode.podspec`中的`user_target_xcconfig`添加此设置后会导致`SmartCodable_Example`设置中的`SUPPORTS_MACCATALYST`也被开启，从而对主`target`造成影响。

![image](https://github.com/user-attachments/assets/cb988a84-d0ef-486e-92ee-2d92f0618638)

`Cocoapods`官方文档中也提到不建议使用 **[user_target_xcconfig](https://guides.cocoapods.org/syntax/podspec.html#user_target_xcconfig)**

![image](https://github.com/user-attachments/assets/94fa5315-cbc1-47b4-90a4-0c31e3bc3895)
