### PR TITLE
enable BUILD_LIBRARY_FOR_DISTRIBUTION

### DIFF
--- a/SmartCodable.podspec
+++ b/SmartCodable.podspec
@@ -34,6 +34,9 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'Sources/SmartCodable/Core/**/*{.swift}'
+    ss.pod_target_xcconfig = {
+      'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
+    }
   end
   
   
@@ -48,7 +51,8 @@ Pod::Spec.new do |s|
 
     ss.pod_target_xcconfig = {
       "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/SmartCodable/release/SmartCodableMacros-tool#SmartCodableMacros",
-      "SUPPORTS_MACCATALYST" => "YES"
+      "SUPPORTS_MACCATALYST" => "YES",
+      'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
     }
 
     ss.user_target_xcconfig = {


### PR DESCRIPTION
此问题源于QQ群中群友提到的一个警告：
```
Module 'SmartCodable' was not compiled with library evolution support; using it means binary compatibility for 'TSNetworkPod' can't be guaranteed
```
而且`SUPPORTS_MACCATALYST` 这个设置在`SPM`中是默认开启的，所以建议默认打开。 前一阵有热心朋友对[Kinfisher](https://github.com/onevcat/Kingfisher) 贡献过类似的 `PR`，原因给的比较详细，参见：[Kinfisher #2372](https://github.com/onevcat/Kingfisher/pull/2372)

