### PR TITLE
revert #78

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+.DS_Store

--- a/SmartCodable.podspec
+++ b/SmartCodable.podspec
@@ -34,9 +34,6 @@ Pod::Spec.new do |s|
 
   s.subspec 'Core' do |ss|
     ss.source_files = 'Sources/SmartCodable/Core/**/*{.swift}'
-    ss.pod_target_xcconfig = {
-      'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
-    }
   end
   
   
@@ -51,8 +48,7 @@ Pod::Spec.new do |s|
 
     ss.pod_target_xcconfig = {
       "OTHER_SWIFT_FLAGS" => "-Xfrontend -load-plugin-executable -Xfrontend $(PODS_BUILD_DIR)/SmartCodable/release/SmartCodableMacros-tool#SmartCodableMacros",
-      "SUPPORTS_MACCATALYST" => "YES",
-      'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES'
+      "SUPPORTS_MACCATALYST" => "YES"
     }
 
     ss.user_target_xcconfig = {


### PR DESCRIPTION
`BUILD_LIBRARY_FOR_DISTRIBUTION` 在 未开启 `use_frameworks!` 的`pod`工程中会报 `circular reference` 的错误，是因为 `public typealias SmartCodable = SmartCodable.SmartDecodable & SmartCodable.SmartEncodable` 与包名 `SmartCodable` 冲突导致的。 #80 
![image](https://github.com/user-attachments/assets/965bd80b-027d-4797-bc75-cda935d94906)

### 解决办法：
1. 在`podfile`中开启 `use_frameworks!`
2. 修改包名：在`podspec` 中添加如下设置 
```ruby 
# 名称随意定的
s.module_name = "SmartCodableKit" 
```
3. 禁止 `verify`:
```ruby
s.pod_target_xcconfig = {
    'OTHER_SWIFT_FLAGS' => '-no-verify-emitted-module-interface'
}
```
4. 关闭 `BUILD_LIBRARY_FOR_DISTRIBUTION`设置

第2种方案会导致所有`import SmartCodable`的地方需要换成`import SmartCodableKit`，从影响面上考虑，第3、4种方案是最小的